### PR TITLE
Implementation of the 'fetch' command

### DIFF
--- a/assignment1/client.py
+++ b/assignment1/client.py
@@ -4,13 +4,19 @@ from _thread import *
 import asyncio
 import logging
 import socket
+import json
+import random
+import file_transfer
 import sys
+import socketserver
 
 logging.basicConfig(format='%(asctime)s %(lineno)d %(levelname)s:%(message)s', level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 HOST = '0.0.0.0'
 PORT = 8080
+PEER_SRV_PORT = None
+REPOSITORY_DIR = "./"
 
 class UnknownCommandError(Exception):
     def __init__(self, cmd):
@@ -39,13 +45,55 @@ def handle_publish(lname, fname, conn):
     """TODO: publish file to server"""
     host, port = server_addr
 
-def handle_fetch(fname, conn):
+def get_peers_from_srv(fname: str, host: str, port: int):
+    """ Retrieve all peers that contain 'fname' in their repositories.
+
+    Args:
+        fname(str): name of the file being requested 
+        host(str): ipv4 address of the server
+        port(str): port on which the server listens 
+
+    Returns:
+        list: A list of string representing peers in the following format: "{host}:{port}"
+    """
+
+    fetch_req = file_transfer.create_fetch_request(fname)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.connect((host, port))
+        sock.send(fetch_req)
+        raw_resp = sock.recv(1024)
+        peers = json.loads(raw_resp)
+        return peers
+
+
+def handle_fetch_cmd(fname, conn):
     """TODO: send request to server
         -> server return data consist of peer host and port
         -> send request retrieve file from peer
         -> peer send back file (using ftp)
     """
 
+    logger.info(f"Fetching file '{fname}'...")
+
+    """ TODO: handle the case that there exists a file named 'fname' in the repository. """
+
+    peers = get_peers_from_srv(fname, server_host, server_port)
+    logger.debug(f"Peers containing '{fname}': {peers}")
+
+    if peers == []:
+        print(f"No file named '{fname}' was published.")
+        return
+
+    # Pick a random peer
+    peer: str = random.choice(peers)
+    logger.debug(f"Choose peer: {peer}")
+
+    # peer's host, peer's port
+    p_host, p_port = peer
+
+    file_transfer.fetch_file(fname=fname, host=p_host, port=p_port, file_dir=f"{REPOSITORY_DIR}")
+    logger.debug(f"Fetched file '{fname}' from peer {peer}.")
+    print(f"Successfully fetched {fname}.")
 
 def shell_command_handler(conn):
     while True:
@@ -55,12 +103,11 @@ def shell_command_handler(conn):
             if cmd == 'publish':
                 handle_publish(args[0], args[1], conn)
             elif cmd == 'fetch':
-                handle_fetch(args, conn)
+                handle_fetch_cmd(args, conn)
         except UnknownCommandError as e:
             print_usage()
         except IndexError:
             print_usage()
-
 
 def handle_request_from_server(conn):
     while True:
@@ -72,21 +119,74 @@ def handle_request_from_server(conn):
         # TODO:
         # handle 'discover' request from server
 
+class PeerRequestHandler(socketserver.BaseRequestHandler):
+    def is_fetch_request(self, raw_req: bytes):
+        """ Check if the raw request is a `fetch` request. """
+        fields = ['op', 'fname']
+        parsed_rq : dict = json.loads(raw_req)
+        for field in fields:
+            if field not in parsed_rq.keys():
+                return False
+        
+        return parsed_rq['op'] == 'fetch' and isinstance(parsed_rq['fname'], str)
+
+    def is_validate_request(self, raw_req: bytes):
+        """ Check if the raw request is a `validate` request.
+            A `validate` request is used to ask a peer whether the file `fname`
+            still exists in its repository.
+        """
+        fields = ['op', 'fname']
+        parsed_rq : dict = json.loads(raw_req)
+        for field in fields:
+            if field not in parsed_rq.keys():
+                return False
+        
+        return parsed_rq['op'] == 'validate' and isinstance(parsed_rq['fname'], str)
+
+    def handle(self):
+        """ Handle incoming requests from other peers. """
+        raw_req = self.request.recv(1024)
+        if self.is_fetch_request(raw_req):
+            parsed_req = json.loads(raw_req)
+            fname = parsed_req['fname']
+            with open(f"{REPOSITORY_DIR}/{fname}", "rb") as f:
+                chunk = f.read(8192)
+                while chunk:
+                    self.request.send(chunk)
+                    chunk = f.read(8192)
+
+def handle_request_from_peer(peer_srv: socketserver.TCPServer):
+    try:
+        peer_srv.serve_forever()
+    finally:
+        peer_srv.server_close()
+
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('-H', '--server-host')
     arg_parser.add_argument('-P', '--server-port')
+    arg_parser.add_argument('--peer-srv-port')
+    arg_parser.add_argument('--shared-repo')
     args = arg_parser.parse_args()
     server_host = args.server_host or 'localhost'
     server_port = int(args.server_port or '8080')
+
+    # if the seeding server's port is not specified, tell Python to choose a random unused port
+    PEER_SRV_PORT = int(args.peer_srv_port or 0)    
+    REPOSITORY_DIR = args.shared_repo
 
     try:
         server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         server.connect((server_host, server_port))
 
         start_new_thread(handle_request_from_server, (server,))
+        peer_srv = socketserver.ThreadingTCPServer(('', PEER_SRV_PORT), PeerRequestHandler)
+        PEER_SRV_PORT = peer_srv.server_address[1]
+        print(f"Start listening from other peers at port {PEER_SRV_PORT}.")
+
+        # Create new PyThread to handle request from other peers
+        start_new_thread(handle_request_from_peer, (peer_srv,))
 
         shell_command_handler(server)
     finally:
         server.close()
-

--- a/assignment1/client.py
+++ b/assignment1/client.py
@@ -59,9 +59,23 @@ def handle_publish(lname, fname, conn):
     """TODO: publish file to server"""
 
     try:
-
-        file_mapping_table[fname] = lname
+        if fname in file_mapping_table:
+            if file_mapping_table[fname] == lname:
+                print('File has been published before.')
+            elif file_mapping_table[fname] != lname:
+                print(f'File named {fname} already exists. Update present local path of {fname} to new local path {lname}.')
+                file_mapping_table[fname] = lname
+        elif lname in file_mapping_table:
+            for file_name, local_path in file_mapping_table.items():
+                if local_path == lname and file_name != fname:
+                    print(f'Local path {lname} belongs to a file with different name than {fname}. Update name of file to {fname}.')
+                    del file_mapping_table[fname]
+                    file_mapping_table[fname] = lname
+                    break
+        else:
+            file_mapping_table[fname] = lname
         print(file_mapping_table)
+    
         message = json.dumps({'publish' : fname, 'seeding_port': PEER_SRV_PORT})
         try:
             conn.sendall(message.encode('utf-8'))

--- a/assignment1/client.py
+++ b/assignment1/client.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 HOST = '0.0.0.0'
 PORT = 8080
+PEER_SRV_HOST = ""
 PEER_SRV_PORT = None
 REPOSITORY_DIR = "./"
 
@@ -66,7 +67,7 @@ def get_peers_from_srv(fname: str, host: str, port: int):
         return peers
 
 
-def handle_fetch_cmd(fname, conn):
+def handle_fetch_cmd(fname):
     """TODO: send request to server
         -> server return data consist of peer host and port
         -> send request retrieve file from peer
@@ -93,7 +94,7 @@ def handle_fetch_cmd(fname, conn):
 
     file_transfer.fetch_file(fname=fname, host=p_host, port=p_port, file_dir=f"{REPOSITORY_DIR}")
     logger.debug(f"Fetched file '{fname}' from peer {peer}.")
-    print(f"Successfully fetched {fname}.")
+    print(f"Successfully fetched '{fname}'.")
 
 def shell_command_handler(conn):
     while True:
@@ -165,6 +166,7 @@ if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('-H', '--server-host')
     arg_parser.add_argument('-P', '--server-port')
+    arg_parser.add_argument('--peer-srv-host')
     arg_parser.add_argument('--peer-srv-port')
     arg_parser.add_argument('--shared-repo')
     args = arg_parser.parse_args()
@@ -172,6 +174,7 @@ if __name__ == '__main__':
     server_port = int(args.server_port or '8080')
 
     # if the seeding server's port is not specified, tell Python to choose a random unused port
+    PEER_SRV_HOST = (args.peer_srv_host or "")
     PEER_SRV_PORT = int(args.peer_srv_port or 0)    
     REPOSITORY_DIR = args.shared_repo
 
@@ -180,7 +183,7 @@ if __name__ == '__main__':
         server.connect((server_host, server_port))
 
         start_new_thread(handle_request_from_server, (server,))
-        peer_srv = socketserver.ThreadingTCPServer(('', PEER_SRV_PORT), PeerRequestHandler)
+        peer_srv = socketserver.ThreadingTCPServer((PEER_SRV_HOST, PEER_SRV_PORT), PeerRequestHandler)
         PEER_SRV_PORT = peer_srv.server_address[1]
         print(f"Start listening from other peers at port {PEER_SRV_PORT}.")
 

--- a/assignment1/file_transfer.py
+++ b/assignment1/file_transfer.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+import json
+import asyncio
+import socket
+
+def create_fetch_request(fname) -> bytes:
+    req = {
+        'op': 'fetch',
+        'fname': fname
+    }
+
+    return json.dumps(req).encode()
+
+def is_fetch_request(raw_req: bytes):
+    """ Check if the raw request is a `fetch` request. """
+    fields = ['op', 'fname']
+    parsed_rq : dict = json.loads(raw_req)
+    for field in fields:
+        if field not in parsed_rq.keys():
+            return False
+        
+    return parsed_rq['op'] == 'fetch' and isinstance(parsed_rq['fname'], str)
+    
+
+
+def fetch_file(fname, host, port, file_dir):
+    """ Fetch file 'fname' from peer 'peer'.
+
+    Args:
+        fname (str): name of the file being request in peer's repository.
+        host (str): ipv4 address of the peer whose file is requested.
+        port (int): port number of the peer.
+        file_dir (str): the place to store the file being downloaded.
+    """
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.connect((host, port))
+        file_rq = create_fetch_request(fname)
+
+        sock.send(file_rq)
+
+        with open(f"{file_dir}/{fname}", 'wb') as f:
+            data = sock.recv(8192)
+            while data:
+                f.write(data)
+                data = sock.recv(8192)

--- a/assignment1/server.py
+++ b/assignment1/server.py
@@ -102,7 +102,10 @@ def handle_conn(conn, client_addr):
                     print("Published_file received from client: ")
                     fname = json_data['publish']
                     if fname in database:
-                        database[fname].append((conn.getpeername()[0], json_data['seeding_port']))
+                        if (conn.getpeername()[0], json_data['seeding_port']) in database.values():
+                            pass
+                        else:
+                            database[fname].append((conn.getpeername()[0], json_data['seeding_port']))
                     else:
                         database[fname] = [(conn.getpeername()[0], json_data['seeding_port'])]
                     print(database)


### PR DESCRIPTION
Modification for the `publish` command: Client has to send the port on which it listens to other peers (by adding a `seeding_port` field in the `publish` request)

Implement `fetch` command

Add more flags for `client.py`, including:

- --peer-srv-host, --peer-srv-port: address at which the host listens to other peers.
-  --default-dest: path to the location where  downloaded files will be placed.